### PR TITLE
Fix package name

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "Assembling GOPATH..."
-PACKAGE_NAME="github.com/golang-starters/golang-health-check"
+PACKAGE_NAME="github.com/golang-starters/golang-http-crud"
 export GOPATH=`realpath $HOME/go`
 echo "Assembling GOPATH... DONE"
 


### PR DESCRIPTION
Change package name from `golang-health-check` to `golang-http-crud`.

This change doesn't affect anything apart from the directory name where project is stored.